### PR TITLE
Ignore Debian root symlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,4 @@ sw.js
 packaging/jellyfin-vue*
 
 *storybook.log
+packaging/deb/root

--- a/packaging/deb/.gitignore
+++ b/packaging/deb/.gitignore
@@ -7,3 +7,5 @@ frontend
 package-lock.json
 package.json
 .npmrc
+
+root

--- a/packaging/deb/README.md
+++ b/packaging/deb/README.md
@@ -5,3 +5,5 @@
 2. Build the package:
 
 `dpkg-buildpackage -us -uc`
+
+The `root` symlink in this directory points to the repository root and is used by the Debian packaging scripts to access the entire project tree during the build process.


### PR DESCRIPTION
## Summary
- ignore the `packaging/deb/root` symlink
- document the symlink purpose in Debian packaging docs

## Testing
- `npm ci`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688911dd4d00832c93bfbbf299c926b4