### PR TITLE
Add test selectors helper with tests

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,7 +25,8 @@
     "serve": "vite preview --configLoader runner",
     "prod": "npm run build && npm run serve",
     "clean": "git clean -fxd",
-    "storybook": "storybook dev -p 6006 --config-dir storybook --no-open"
+    "storybook": "storybook dev -p 6006 --config-dir storybook --no-open",
+    "test": "vitest run"
   },
   "dependencies": {
     "@fontsource-variable/figtree": "5.2.8",

--- a/frontend/src/utils/testSelectors.ts
+++ b/frontend/src/utils/testSelectors.ts
@@ -1,0 +1,7 @@
+/**
+ * Helper to create `data-test` attributes for easier unit test selectors.
+ *
+ * @param id - Identifier for the test selector.
+ * @returns Object containing the `data-test` attribute.
+ */
+export const testSel = (id: string) => ({ 'data-test': id });

--- a/frontend/tests/testSelectors.spec.ts
+++ b/frontend/tests/testSelectors.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from 'vitest';
+import { testSel } from '../src/utils/testSelectors';
+
+test('returns data-test attribute object', () => {
+  expect(testSel('foo')).toEqual({ 'data-test': 'foo' });
+});

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node'
+  }
+});


### PR DESCRIPTION
## Summary
- add `testSel` helper for creating data-test selectors
- configure Vitest for frontend tests
- add unit test for the helper

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68892ba4ae94832cb87a0fa269c6c7fe