### PR TITLE
Add server store with URL normalization

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,6 +25,7 @@
     "serve": "vite preview --configLoader runner",
     "prod": "npm run build && npm run serve",
     "clean": "git clean -fxd",
+    "test": "vitest run",
     "storybook": "storybook dev -p 6006 --config-dir storybook --no-open"
   },
   "dependencies": {
@@ -48,6 +49,7 @@
     "i18next": "25.2.1",
     "i18next-vue": "5.3.0",
     "libpgs": "0.8.1",
+    "pinia": "2.1.7",
     "sortablejs": "1.15.6",
     "swiper": "11.2.9",
     "uuid": "11.1.0",

--- a/frontend/src/stores/server.ts
+++ b/frontend/src/stores/server.ts
@@ -1,0 +1,30 @@
+import { defineStore } from 'pinia';
+
+/**
+ * Normalize a Jellyfin server URL by trimming whitespace, removing trailing
+ * slashes and ensuring a protocol is present.
+ *
+ * @param url - Raw server URL input
+ * @returns Normalized server URL
+ */
+export function normalizeServerUrl(url: string): string {
+  let value = url.trim();
+  // remove trailing slashes
+  value = value.replace(/\/+$/, '');
+  // prepend protocol if missing
+  if (!/^https?:\/\//i.test(value) && value !== '') {
+    value = `http://${value}`;
+  }
+  return value;
+}
+
+export const useServerStore = defineStore('server', {
+  state: () => ({
+    url: ''
+  }),
+  actions: {
+    setUrl(newUrl: string) {
+      this.url = normalizeServerUrl(newUrl);
+    }
+  }
+});

--- a/frontend/tests/server.spec.ts
+++ b/frontend/tests/server.spec.ts
@@ -1,0 +1,33 @@
+import { setActivePinia, createPinia } from 'pinia';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { normalizeServerUrl, useServerStore } from '../src/stores/server.ts';
+
+describe('normalizeServerUrl', () => {
+  it('trims whitespace', () => {
+    expect(normalizeServerUrl('  http://example.com  ')).toBe('http://example.com');
+  });
+
+  it('removes trailing slashes', () => {
+    expect(normalizeServerUrl('http://example.com/')).toBe('http://example.com');
+  });
+
+  it('adds protocol when missing', () => {
+    expect(normalizeServerUrl('example.com')).toBe('http://example.com');
+  });
+
+  it('keeps existing protocol', () => {
+    expect(normalizeServerUrl('https://example.com')).toBe('https://example.com');
+  });
+});
+
+describe('useServerStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  it('stores normalized server url', () => {
+    const store = useServerStore();
+    store.setUrl(' example.com/ ');
+    expect(store.url).toBe('http://example.com');
+  });
+});

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true
+  }
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,6 +64,7 @@
         "i18next": "25.2.1",
         "i18next-vue": "5.3.0",
         "libpgs": "0.8.1",
+        "pinia": "2.1.7",
         "sortablejs": "1.15.6",
         "swiper": "11.2.9",
         "uuid": "11.1.0",
@@ -82,6 +83,58 @@
         "unplugin-vue-components": "28.7.0",
         "unplugin-vue-router": "0.12.0",
         "vite-plugin-vue-devtools": "7.7.7"
+      }
+    },
+    "frontend/node_modules/pinia": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/pinia/-/pinia-2.1.7.tgz",
+      "integrity": "sha512-+C2AHFtcFqjPih0zpYuvof37SFxMQ7OEG2zV9jRI12i9BOy3YQVAHwdKtyyc8pDcDyIc33WCIsZaCFWU7WWxGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-api": "^6.5.0",
+        "vue-demi": ">=0.14.5"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/posva"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.4.0",
+        "typescript": ">=4.4.4",
+        "vue": "^2.6.14 || ^3.3.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "frontend/node_modules/vue-demi": {
+      "version": "0.14.10",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
+      "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "vue-demi-fix": "bin/vue-demi-fix.js",
+        "vue-demi-switch": "bin/vue-demi-switch.js"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.0.0-rc.1",
+        "vue": "^3.0.0-0 || ^2.6.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
       }
     },
     "node_modules/@adobe/css-tools": {


### PR DESCRIPTION
## Summary
- implement `normalizeServerUrl` utility and expose server URL via Pinia store
- add vitest config for frontend and unit tests for server normalization
- include pinia dependency and test script

## Testing
- `npm test'