### PR TITLE
Add server URL validation

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,7 +25,8 @@
     "serve": "vite preview --configLoader runner",
     "prod": "npm run build && npm run serve",
     "clean": "git clean -fxd",
-    "storybook": "storybook dev -p 6006 --config-dir storybook --no-open"
+    "storybook": "storybook dev -p 6006 --config-dir storybook --no-open",
+    "test": "vitest run"
   },
   "dependencies": {
     "@fontsource-variable/figtree": "5.2.8",

--- a/frontend/src/components/Forms/AddServerForm.vue
+++ b/frontend/src/components/Forms/AddServerForm.vue
@@ -49,6 +49,8 @@ import { useTranslation } from 'i18next-vue';
 import { useRouter } from 'vue-router';
 import { remote } from '#/plugins/remote';
 import { jsonConfig } from '#/utils/external-config';
+import { normalizeServerUrl } from '#/stores/server';
+import { useAddServerRules } from './addServerRules';
 
 const router = useRouter();
 const { t } = useTranslation();
@@ -57,9 +59,7 @@ const previousServerLength = remote.auth.addedServers.value;
 const serverUrl = shallowRef('');
 const loading = shallowRef(false);
 
-const rules = [
-  (v: string): boolean | string => !!v.trim() || t('required')
-];
+const rules = useAddServerRules();
 
 /**
  * Attempts a connection to the given server.
@@ -70,7 +70,7 @@ async function connectToServer(): Promise<void> {
   loading.value = true;
 
   try {
-    await remote.auth.connectServer(serverUrl.value);
+    await remote.auth.connectServer(normalizeServerUrl(serverUrl.value));
     await router.push('/server/login');
   } finally {
     loading.value = false;

--- a/frontend/src/components/Forms/addServerRules.ts
+++ b/frontend/src/components/Forms/addServerRules.ts
@@ -1,0 +1,10 @@
+import { isValidServerUrl } from '#/stores/server';
+import { useTranslation } from 'i18next-vue';
+
+export function useAddServerRules() {
+  const { t } = useTranslation();
+  return [
+    (v: string): boolean | string => !!v.trim() || t('required'),
+    (v: string): boolean | string => isValidServerUrl(v) || t('invalidUrl')
+  ];
+}

--- a/frontend/src/stores/server.ts
+++ b/frontend/src/stores/server.ts
@@ -1,0 +1,18 @@
+export function normalizeServerUrl(url: string): string {
+  let normalized = url.trim();
+  if (!/^https?:\/\//i.test(normalized)) {
+    normalized = `http://${normalized}`;
+  }
+  normalized = normalized.replace(/\/+$/, '');
+  return normalized;
+}
+
+export function isValidServerUrl(url: string): boolean {
+  try {
+    // new URL throws if invalid
+    void new URL(normalizeServerUrl(url));
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/frontend/test/add-server-form.spec.ts
+++ b/frontend/test/add-server-form.spec.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeServerUrl, isValidServerUrl } from '#/stores/server';
+
+describe('normalizeServerUrl', () => {
+  it('adds http scheme if missing', () => {
+    expect(normalizeServerUrl('example.com')).toBe('http://example.com');
+  });
+
+  it('removes trailing slashes', () => {
+    expect(normalizeServerUrl('https://example.com/')).toBe('https://example.com');
+  });
+});
+
+describe('isValidServerUrl', () => {
+  it('accepts valid urls', () => {
+    expect(isValidServerUrl('http://example.com')).toBe(true);
+    expect(isValidServerUrl('https://example.com')).toBe(true);
+  });
+
+  it('rejects invalid urls', () => {
+    expect(isValidServerUrl('not a url')).toBe(false);
+  });
+});

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+import Vue from '@vitejs/plugin-vue';
+
+export default defineConfig({
+  plugins: [Vue()],
+  test: {
+    environment: 'node'
+  }
+});


### PR DESCRIPTION
## Summary
- validate server URL format in AddServerForm
- normalize URL before connecting
- provide server url normalization utilities
- set up vitest in frontend and add tests

## Testing
- `npm ci`
- `npm run build`
- `npm test`