### PR TITLE
Fix duplicate server URL normalizer

### DIFF
--- a/frontend/src/stores/server.ts
+++ b/frontend/src/stores/server.ts
@@ -1,9 +1,18 @@
+import { defineStore } from 'pinia';
+
+/**
+ * Normalize a Jellyfin server URL by trimming whitespace, removing trailing
+ * slashes and ensuring a protocol is present.
+ *
+ * @param url - Raw server URL input
+ * @returns Normalized server URL
+ */
 export function normalizeServerUrl(url: string): string {
   let normalized = url.trim();
-  if (!/^https?:\/\//i.test(normalized)) {
+  normalized = normalized.replace(/\/+$/, '');
+  if (!/^https?:\/\//i.test(normalized) && normalized !== '') {
     normalized = `http://${normalized}`;
   }
-  normalized = normalized.replace(/\/+$/, '');
   return normalized;
 }
 
@@ -15,26 +24,6 @@ export function isValidServerUrl(url: string): boolean {
   } catch {
     return false;
   }
-}
-
-import { defineStore } from 'pinia';
-
-/**
- * Normalize a Jellyfin server URL by trimming whitespace, removing trailing
- * slashes and ensuring a protocol is present.
- *
- * @param url - Raw server URL input
- * @returns Normalized server URL
- */
-export function normalizeServerUrl(url: string): string {
-  let value = url.trim();
-  // remove trailing slashes
-  value = value.replace(/\/+$/, '');
-  // prepend protocol if missing
-  if (!/^https?:\/\//i.test(value) && value !== '') {
-    value = `http://${value}`;
-  }
-  return value;
 }
 
 export const useServerStore = defineStore('server', {


### PR DESCRIPTION
## Summary
- dedupe `normalizeServerUrl` implementation
- keep `isValidServerUrl` and `useServerStore` exports using single function

## Testing
- `npm ci`
- `npm run build`
- `npm test`