### PR TITLE
Fix vitest config

### DIFF
--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,19 +1,4 @@
-import { defineConfig } from 'vitest/config';
-import vue from '@vitejs/plugin-vue';
+import { defineConfig } from 'vitest/config'
+import vue from '@vitejs/plugin-vue'
 
-export default defineConfig({
-  plugins: [vue()]
-});
-
-import Vue from '@vitejs/plugin-vue';
-
-export default defineConfig({
-  plugins: [Vue()],
-  test: {
-    environment: 'node'
-  }
-});
-
-export default defineConfig({
-  test: {
-  });
+export default defineConfig({ plugins: [vue()], test: { environment: 'node' } })


### PR DESCRIPTION
## Summary
- fix vitest config by removing duplicate exports

## Testing
- `npm run build`
- `CI=1 npm test`